### PR TITLE
Updating dev db, gitlabci and docker python images to a lighter version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - deploy
 
 unit tests:
-  image: python:3
+  image: python:3.5.6-slim-stretch
   before_script:
     - pip install -r login/requirements/dev.txt
   stage: test
@@ -12,7 +12,7 @@ unit tests:
     - sh run-tests.sh
 
 publish codecov:
-  image: python:3
+  image: python:3.5.6-slim-stretch
   before_script:
     - pip install -r login/requirements/dev.txt
   only:
@@ -28,7 +28,7 @@ publish image to production:
   image: docker:stable
   services:
     - docker:dind
-    - docker:python:3
+    - docker:python:3.5.6-slim-stretch
   before_script:
     - docker info
   only:
@@ -37,21 +37,21 @@ publish image to production:
   script:
     - sh run-publish-docker.sh production
 
-# publish image to staging:
-#   image: docker:stable
-#   services:
-#     - docker:dind
-#     - docker:python:3
-#   before_script:
-#     - docker info
-#   only:
-#     - dev
-#   stage: publish
-#   script:
-#     - sh run-publish-docker.sh staging
+publish image to staging:
+  image: docker:stable
+  services:
+    - docker:dind
+    - docker:python:3.5.6-slim-stretch
+  before_script:
+    - docker info
+  only:
+    - dev
+  stage: publish
+  script:
+    - sh run-publish-docker.sh staging
 
 deploy to production:
-  image: python:3
+  image: python:3.5.6-slim-stretch
   only:
     - tags
   stage: deploy
@@ -60,7 +60,7 @@ deploy to production:
     - sh run-deploy.sh production
 
 # deploy to staging:
-#   image: python:3
+#   image: python:3.5.6-slim-stretch
 #   only:
 #     - dev
 #   stage: deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.5.6-slim-stretch
 ENV PYTHONUNBUFFERED 1
 
 RUN mkdir /code

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,11 @@ default:
 run:
 	echo NEED_UPDATE
 
+tests:
+	docker-compose exec web bash -c "sh run-tests.sh"
+
+enter:
+	docker-compose exec web bash
+
 production:
 	docker-compose -f docker-compose-production.yml up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
-version: '3.6'
+version: '3.3'
 
 services:
-  db:
-    image: postgres:10.1-alpine
-    volumes:
-      - postgres_data:/var/lib/postgresql/data/
   web:
     build: .
     command: bash -c "sh run-django.sh"
@@ -13,8 +9,3 @@ services:
     ports:
       - 8000:8000
       - 587:587
-    depends_on:
-      - db
-
-volumes:
-  postgres_data:

--- a/login/login/settings/development.py
+++ b/login/login/settings/development.py
@@ -8,11 +8,8 @@ ALLOWED_HOSTS = ["*"]
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'postgres',
-        'USER': 'postgres',
-        'HOST': 'db', # set in docker-compose.yml
-        'PORT': 5432 # default postgres port
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
 

--- a/login/login/urls.py
+++ b/login/login/urls.py
@@ -17,8 +17,11 @@ urlpatterns = [
     url('^', include('django.contrib.auth.urls')),
 ]
 
-site = Site.objects.get(id=1)
-site.name = LOGIN_DEFAULT_DOMAIN
-site.domain = LOGIN_DEFAULT_DOMAIN
-site.save()
-current_domain = LOGIN_DEFAULT_DOMAIN
+try:
+    site = Site.objects.get(id=1)
+    site.name = LOGIN_DEFAULT_DOMAIN
+    site.domain = LOGIN_DEFAULT_DOMAIN
+    site.save()
+    current_domain = LOGIN_DEFAULT_DOMAIN
+except:
+    print('please re-run the server')

--- a/login/requirements/base.txt
+++ b/login/requirements/base.txt
@@ -3,5 +3,5 @@ djangorestframework==3.8.2
 djangorestframework-jwt==1.11.0
 django-rest-auth==0.9.3
 django-allauth==0.37.1
-psycopg2==2.7.5
+psycopg2-binary==2.7.5
 python-decouple==3.1

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.5.6-slim-stretch
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /code


### PR DESCRIPTION
## Descrição
Atualizações gerais

soluciona issue #15 

Tarefas gerais realizadas
* Atualização do gitlabci para voltar a gerar imagens latets a partir da branch dev
* Mudando banco de dados de desenvolvimento para sqlite
* Atualizando imagens do python:3 para python:3.5.6-slim-stretch... uma versão 10x menor que melhorará o tempo de build do CI
