### PR TITLE
Adicionando testes de verificação do container e Corrigindo settings do django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
         - docker
       name: "Checking Container Run"
       script:
-        - make check-service container=login-microservice
+        - make check-service
 
     - stage: test
       name: "Unit Tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,6 @@ language: python
 python:
   - "3.4"
 
-cache: pip
-
-install:
-  - pip install -r login/requirements/dev.txt
-
-virtualenv:
-  system_site_packages: true
-
 stages:
   - check-container
   - test
@@ -21,11 +13,24 @@ jobs:
       sudo: required
       services:
         - docker
-      name: "Checking Container Run"
+      name: "Checking Production Container Run"
       script:
-        - make check-service
+        - make check-docker-production
+
+    - stage: check-container
+      sudo: required
+      services:
+        - docker
+      name: "Checking Development Container Run"
+      script:
+        - make check-docker-dev
 
     - stage: test
+      virtualenv:
+        system_site_packages: true
+      cache: pip
+      install:
+        - pip install -r login/requirements/dev.txt
       name: "Unit Tests"
       script: sh run-tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,21 @@ virtualenv:
   system_site_packages: true
 
 stages:
+  - check-container
   - test
 
 jobs:
   include:
-    - stage: "Tests"
+    - stage: check-container
+      sudo: required
+      services:
+        - docker
+      name: "Checking Container Run"
+      script:
+        - make check-service container=login-microservice
+
+    - stage: test
       name: "Unit Tests"
       script: sh run-tests.sh
+
+    

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ down:
 
 check-service:
 	make &
-	sleep 60
-	docker inspect -f '{{.State.Running}}' ${container}
+	sleep 40
+	bash -c "[ -z "$(docker ps -q -f status=ok)" ] && exit 1"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ production:
 down:
 	docker-compose down
 
-check-service:
+check-docker-production:
+	make production &
+	sleep 80
+	bash -c "[ -z "$(docker ps -q -f status=ok)" ] && exit 1"
+
+check-docker-dev:
 	make &
-	sleep 40
+	sleep 60
 	bash -c "[ -z "$(docker ps -q -f status=ok)" ] && exit 1"

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,12 @@ down:
 
 check-docker-production:
 	make production &
-	sleep 80
-	bash -c "[ -z "$(docker ps -q -f status=ok)" ] && exit 1"
+	sleep 60
+	bash check-container.sh
+	docker-compose -f docker-compose-production.yml down
 
 check-docker-dev:
 	make &
 	sleep 60
-	bash -c "[ -z "$(docker ps -q -f status=ok)" ] && exit 1"
+	bash check-container.sh
+	make down

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,8 @@ production:
 
 down:
 	docker-compose down
+
+check-service:
+	make &
+	sleep 60
+	docker inspect -f '{{.State.Running}}' ${container}

--- a/check-container.sh
+++ b/check-container.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+function checkService(){
+
+    rm -rf ./container-result-file
+    docker ps -q -f status=exited | cat >> ./container-result-file
+
+    cat ./container-result-file | while read line
+    do
+        rm -rf ./container-result-file
+        echo "   ✘ service failed!"
+        return 1
+    done
+
+    echo "   ✓ service checked"
+    rm -rf ./container-result-file
+}
+
+checkService

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.3'
 
 services:
   db:

--- a/login/login/settings/common.py
+++ b/login/login/settings/common.py
@@ -44,18 +44,10 @@ INSTALLED_APPS = [
 ]
 
 cloudinary.config(
-    cloud_name=config('CDN_CLOUD_NAME'),
-    api_key=config('CDN_API_KEY'),
-    api_secret=config('CDN_API_SECRET')
+    cloud_name=config('CDN_CLOUD_NAME', default="empty"),
+    api_key=config('CDN_API_KEY', default="empty"),
+    api_secret=config('CDN_API_SECRET', default="empty")
 )
-
-#EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_PORT = 587
-EMAIL_HOST_USER = 'integraappfga@gmail.com'
-EMAIL_HOST_PASSWORD = config('SECURITY_EMAIL_PASSWORD', default='passwordShouldBeIn.Env')
-EMAIL_USE_TLS = True
-DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 SITE_ID = 1
 


### PR DESCRIPTION
## Descrição
Testes de verificação do container ajudarão a reconhecer quando uma aplicação não consegue subir por falta de algum recurso chave, que testes unitários não pegariam.

**Caso issue esteja em outro repositorio**
soluciona issue fga-eps-mds/2018.2-Integra-Vendas#281
Fix fga-eps-mds/2018.2-Integra-Vendas#280

Tarefas gerais realizadas
* Remoção da configuração de email no commons
* Criação de teste de verificação do container
* Adição do teste de verificação no travis

## Para testar
- Não traz nenhuma funcionalidade nova para ser testada.
- Verificação dos testes já é realizada no Travis
